### PR TITLE
Bump runner version to `debian12`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,7 @@
 version: 2
 updates:
-
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-
-  # Maintain dependencies for docker
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ADD https://github.com/Wind4/vlmcsd/archive/${VERSION}.tar.gz /tmp
 RUN tar -xzf /tmp/${VERSION}.tar.gz --strip-components=1 && \
     CC="clang" make vlmcsd -j$(nproc)
 
-FROM gcr.io/distroless/base-nossl-debian11:nonroot
+FROM gcr.io/distroless/base-nossl-debian12:nonroot
 
 LABEL org.opencontainers.image.description="A rootless container running vlmcsd"
 LABEL org.opencontainers.image.author="Zheng Junyi <zhengjunyi@live.comn>"


### PR DESCRIPTION
Since Dependabot cant update `gcr.io/distroless/base-nossl-debian12` correctly.

To manage it manually.