### PR TITLE
Remove support for riscv64

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -54,7 +54,7 @@ jobs:
         uses: docker/setup-qemu-action@v3.2.0
         id: qemu
         with:
-          platforms: amd64,arm64,riscv64
+          platforms: amd64,arm64
       - name: Build container with rootless by Buildah
         uses: redhat-actions/buildah-build@v2.13
         id: build-image


### PR DESCRIPTION
Since the upstream container is not compatible with riscv64, support for it has been removed.

PR: #51