### PR TITLE
Extend the size limit of the product catalog

### DIFF
--- a/02-extend-size-limit.patch
+++ b/02-extend-size-limit.patch
@@ -1,0 +1,30 @@
+diff --git a/vlmcsd-1113/src/vlmcs.c b/vlmcsd-1113/src/vlmcs.c
+index e3b6cb7..d656348 100644
+--- a/vlmcsd-1113/src/vlmcs.c
++++ b/vlmcsd-1113/src/vlmcs.c
+@@ -236,7 +236,7 @@ __noreturn static void showProducts(PRINTFUNC p)
+ {
+ 	int cols = getLineWidth();
+ 	int itemsPerLine;
+-	uint8_t i;
++	uint16_t i;
+ 	int32_t index;
+ 
+ 
+@@ -253,14 +253,14 @@ __noreturn static void showProducts(PRINTFUNC p)
+ 
+ 	itemsPerLine = cols / (longestString + 10);
+ 	if (!itemsPerLine) itemsPerLine = 1;
+-	uint8_t lines = items / itemsPerLine;
++	uint16_t lines = items / itemsPerLine;
+ 	if (items % itemsPerLine) lines++;
+ 
+ 	for (i = 0; i < lines; i++)
+ 	{
+ 		for (k = 0; k < itemsPerLine; k++)
+ 		{
+-			uint8_t j;
++			uint16_t j;
+ 			index = k * lines + i;
+ 
+ 			if (index >= items) break;


### PR DESCRIPTION
Due to the size limit of `uint8_t`, when the number of product list items exceeds 255 (currently 275), it will cause array out of bounds, ultimately resulting in the product list not being displayed completely.

```
$ docker run --rm --entrypoint=/usr/bin/vlmcs ghcr.io/mogeko/vlmcsd:sha-0c51b26 -x

You may use these product names or numbers:

  1 = Windows Server 2025 Azure Core                          
  2 = Windows Server 2025 Datacenter Azure Edition            
  3 = Windows Server 2025 Datacenter                          
  4 = Windows Server 2025 Standard                            
  5 = Windows Server 2022 Azure Core                          

```

See: https://forums.mydigitallife.net/threads/emulated-kms-servers-on-non-windows-platforms.50234/page-110